### PR TITLE
Omit falsy values

### DIFF
--- a/src/__tests__/applyTransforms.js
+++ b/src/__tests__/applyTransforms.js
@@ -320,4 +320,38 @@ describe("applyTransforms", () => {
         })
   })
 
+  it("should omit falsy value on transform with plain object", () => {
+    apply(
+      {
+        plop: { a: false, b: null, c: undefined, d: "", e: NaN, color: "red" },
+      },
+      {
+        plop: true,
+      }
+        ).toEqual({
+          color: "red",
+        })
+  })
+
+  it("should omit falsy value on transform with a function", () => {
+    apply(
+      {
+        plop(v) {
+          return {
+            a: false,
+            b: null,
+            c: undefined,
+            d: "",
+            e: NaN,
+            color: v,
+          }
+        },
+      },
+      {
+        plop: "blue",
+      }
+        ).toEqual({
+          color: "blue",
+        })
+  })
 })

--- a/src/__tests__/sansSel.js
+++ b/src/__tests__/sansSel.js
@@ -132,6 +132,21 @@ describe("sansSel", () => {
       const renderResult = ss("foo")
       expect(ss(renderResult, "bar").toString()).toEqual("__foo__0 __bar__1")
     })
+
+    it("should omit falsy properties", () => {
+      ss.addRule("foo", {
+        color: "red",
+        fontSize: false,
+        backgroundColor: "",
+        fontWeight: null,
+        textAlign: undefined,
+        margin: NaN,
+      })
+      ss("foo").toString()
+      expect(backend.rules).toEqual([
+        ".__foo__0{color:red;}",
+      ])
+    })
   })
 
   describe("namespace", () => {

--- a/src/applyTransforms.js
+++ b/src/applyTransforms.js
@@ -10,6 +10,8 @@ function applyTransforms(transforms, declarations, transformCache, result) {
   for (property in declarations) {
     const value = declarations[property]
 
+    if (!value && value !== 0) continue
+
     if (property in transforms) {
       const transform = transforms[property]
       const isFunction = typeof transform === "function"


### PR DESCRIPTION
Allow to use conditional statements which can lead to omitted rule :

```js
addRule("text", {
    color: moreContrast ? '#fff' : false,
    backgroundColor: moreContrast ? '#000' : false,
    fontSize: '12px'
})
```

leads to :

```css
/* moreContrast === false */
.text {
    font-Size: "12px";
}
```

instead of :

```css
/* moreContrast === false */
.text {
    color: false;
    background-Color: false;
    font-Size: "12px";
}
```
